### PR TITLE
Make Corefname point to the same file in updatemonitor as in winminer…

### DIFF
--- a/winminer_v1/updatemonitor/updatemonitor.cpp
+++ b/winminer_v1/updatemonitor/updatemonitor.cpp
@@ -17,7 +17,7 @@
 #include "winminer.h"
 
 char *Addrfile = "maddr.dat";
-char *Corefname = "fullnodes.lst";
+char *Corefname = "startnodes.lst";
 
 word32 Coreplist[32];
 byte Needcleanup;


### PR DESCRIPTION
…. Fixes #1.

The updatemonitor hangs at startup since fullnodes.lst does not exist, because it's supposed to be startnodes.lst.