### PR TITLE
Fix request for incorrect nodelist

### DIFF
--- a/winminer_v1/updatemonitor/updatemonitor.cpp
+++ b/winminer_v1/updatemonitor/updatemonitor.cpp
@@ -17,7 +17,7 @@
 #include "winminer.h"
 
 char *Addrfile = "maddr.dat";
-char *Corefname = "startnodes.lst";
+char *Corefname = "fullnodes.lst";
 
 word32 Coreplist[CORELISTLEN];
 byte Needcleanup;

--- a/winminer_v1/winminer/winminer.cpp
+++ b/winminer_v1/winminer/winminer.cpp
@@ -19,8 +19,8 @@
 #pragma comment(lib, "winhttp.lib")
 
 char *Addrfile = "maddr.dat";
-char *Corefname = "startnodes.lst";
-char *WebAddress = "https://www.mochimap.net:8443/";
+char *Corefname = "fullnodes.lst";
+char *WebAddress = "https://www.mochimap.net/";
 
 #define USER_AGENT L"Mochimo Winminer/1.4"
 
@@ -61,8 +61,8 @@ void usage(void)
 		"           -aXXX.XXX.XXX.XXX set IP address to pull block from, exammple: 65.151.42.11\n"
 		"           -pN set TCP port to N (default: 2095)\n"
 		"           -mFILENAME.ADDR mining address is in file (default: maddr.adr)\n"
-		"           -wURL Pull core ip list file from URL (default: https://www.mochimap.net:8443/)\n"
-		"           -cFILENAME.LST read core ip list from file (default: startnodes.lst)\n"
+		"           -wURL Pull core ip list file from URL (default: https://www.mochimap.net/)\n"
+		"           -cFILENAME.LST read core ip list from file (default: fullnodes.lst)\n"
 		"           -tN set Trace to N\n"
 		"           -h  this message\n"
 	);


### PR DESCRIPTION
Apart from being no longer accesible on port 8443, the startnodes.lst
file is not always fully compatible with the Windows Miner, and
fullnodes.lst should be used instead.

The fullnodes.lst file is much like startnodes.lst, except the list is
filtered by nodes that allow a pull of the latest candidate block from
a Linux node, which is a critical dependency of the Windows Miner.
Additionally, the use of port 8443 is no longer required to access the
list. This removes a limitation for people in certain areas where ports
may be restricted. The port will remain open as legacy support until a
point where it is provably no longer in use, after which communication
on that port will be disabled.